### PR TITLE
Unit Tests: get ct compiling on CentOS-5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ check: ct/_ctcheck
 bench: ct/_ctcheck
 	ct/_ctcheck -b
 
-ct/_ctcheck: ct/_ctcheck.o ct/ct.o $(OFILES) $(TOFILES)
+ct/_ctcheck: ct/_ctcheck.o ct/ct.o $(OFILES) $(TOFILES) -lrt
 
 ct/_ctcheck.c: $(TOFILES) ct/gen
 	ct/gen $(TOFILES) >$@.part

--- a/ct/ct.c
+++ b/ct/ct.c
@@ -12,6 +12,7 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <errno.h>
+#include <time.h>
 #include <sys/time.h>
 #include <stdint.h>
 #include "internal.h"
@@ -24,7 +25,7 @@ static int64 bstart, bdur;
 static int btiming; // bool
 static int64 bbytes;
 static const int64 Second = 1000 * 1000 * 1000;
-static const int64 BenchTime = Second;
+static const int64 BenchTime = 1000 * 1000 * 1000;
 static const int MaxN = 1000 * 1000 * 1000;
 
 
@@ -416,7 +417,7 @@ runbench(Benchmark *b)
         runbenchn(b, n);
     }
     if (b->status == 0) {
-        printf("%8d\t%10lld ns/op", n, b->dur/n);
+        printf("%8d\t%10lld ns/op", n, (long long)b->dur/n);
         if (b->bytes > 0) {
             double mbs = 0;
             if (b->dur > 0) {

--- a/ct/ct.c
+++ b/ct/ct.c
@@ -15,6 +15,7 @@
 #include <time.h>
 #include <sys/time.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include "internal.h"
 #include "ct.h"
 
@@ -417,7 +418,7 @@ runbench(Benchmark *b)
         runbenchn(b, n);
     }
     if (b->status == 0) {
-        printf("%8d\t%10lld ns/op", n, (long long)b->dur/n);
+        printf("%8d\t%10" PRId64 " ns/op", n, b->dur/n);
         if (b->bytes > 0) {
             double mbs = 0;
             if (b->dur > 0) {


### PR DESCRIPTION
Fix some bugs that were preventing compilation (at least on CentOD 5).

Add `-lrt` to load the rt libary to prevent this error:
> ct.c:(.text+0x12): undefined reference to `clock_gettime'

Include `time.h` to prevent this error:
> ct/ct.c:47: error: ‘CLOCK_MONOTONIC’ undeclared (first use in this function)

Perform a cast to prevent this error: (on a 64bit arch)
> ct/ct.c:420: warning: format ‘%10lld’ expects type ‘long long int’, but argument 3 has type ‘int64

Don't use an expression in a const definition to prevent this error:
> ct/ct.c:28: error: initializer element is not constant

See pull kr/ct#7