### PR TITLE
Document stats-job values delay and ttr

### DIFF
--- a/doc/protocol.en-US.md
+++ b/doc/protocol.en-US.md
@@ -397,6 +397,8 @@ The `stats-job` data is a YAML file representing a single dictionary of strings 
 * `state` is `ready` or `delayed` or `reserved` or `buried`
 * `pri` is the priority value set by the put, release, or bury commands.
 * `age` is the time in seconds since the put command that created this job.
+* `delay` is the integer number of seconds to wait before putting this job in the ready queue.
+* `ttr` -- time to run -- is the integer number of seconds a worker is allowed to run this job.
 * `time-left` is the number of seconds left until the server puts this job into the ready queue. This number is only meaningful if the job is reserved or delayed. If the job is reserved and this amount of time elapses before its state changes, it is considered to have timed out.
 * `file` is the number of the earliest binlog file containing this job. If -b wasn't used, this will be 0.
 * `reserves` is the number of times this job has been reserved.

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -448,6 +448,12 @@ to scalars. It contains these keys:
 
  - "age" is the time in seconds since the put command that created this job.
 
+ - "delay" is the integer number of seconds to wait before putting this job in
+   the ready queue.
+
+ - "ttr" -- time to run -- is the integer number of seconds a worker is
+   allowed to run this job.
+
  - "time-left" is the number of seconds left until the server puts this job
    into the ready queue. This number is only meaningful if the job is
    reserved or delayed. If the job is reserved and this amount of time


### PR DESCRIPTION
Document delay and ttr values returned by stats-job command. Language borrowed from elsewhere in the docs.