### PR TITLE
Makefile: finish DESTDIR support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-DESTDIR=
 PREFIX=/usr/local
 BINDIR=$(DESTDIR)$(PREFIX)/bin
 CFLAGS=-Wall -Werror\


### PR DESCRIPTION
Support originally added in 0f97427a38cd0c2c2aee00946ebe561453165a50.
I'm sure this was left in accidentally as it resets the variable to ''.