### PR TITLE
Increase LINE_BUF_SIZE to handle longest possible command

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -43,9 +43,9 @@ typedef int(FAlloc)(int, int);
 #define MAX_TUBE_NAME_LEN 201
 
 /* A command can be at most LINE_BUF_SIZE chars, including "\r\n". This value
- * MUST be enough to hold the longest possible command or reply line, which is
- * currently "USING a{200}\r\n". */
-#define LINE_BUF_SIZE 208
+ * MUST be enough to hold the longest possible command ("pause-tube a{200} 4294967295\r\n")
+ * or reply line ("USING a{200}\r\n"). */
+#define LINE_BUF_SIZE 224
 
 /* CONN_TYPE_* are bit masks */
 #define CONN_TYPE_PRODUCER 1

--- a/doc/protocol.en-US.md
+++ b/doc/protocol.en-US.md
@@ -590,7 +590,7 @@ pause-tube <tube-name> <delay>\r\n
 ##### `pause-tube` options
 
 * `<tube>` is the tube to pause
-* `<delay>` is an integer number of seconds to wait before reserving any more jobs from the queue
+* `<delay>` is an integer number of seconds < 2**32 to wait before reserving any more jobs from the queue
 
 ##### `pause-tube` responses
 

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -703,7 +703,7 @@ pause-tube <tube-name> <delay>\r\n
 
  - <tube> is the tube to pause
 
- - <delay> is an integer number of seconds to wait before reserving any more
+ - <delay> is an integer number of seconds < 2**32 to wait before reserving any more
    jobs from the queue
 
 There are two possible responses:


### PR DESCRIPTION
This fix addresses https://github.com/kr/beanstalkd/issues/211 and https://github.com/kr/beanstalkd/issues/212. 

I tried the approach I suggested in the issue of changing prot.c:343 to use ```>``` instead of ```>=```, but trying to use a tube with a name of length 200 continued having issues. Also given the number of other commands having length issues, this approach would not have solved the larger problem.

So this instead updates LINE_BUF_SIZE to handle the longest possible command and reply lines.

This may be a preferable approach since both LINE_BUF_SIZE and MAX_TUBE_NAME_LEN follow similar logic in that they both represent the minimum invalid length.

Existing ct tests all pass. Additionally a suite of ~200 integration tests I wrote to test adherence to the beanstalk protocol show no regressions. Those tests can be found here: https://github.com/tdg5/beanstalk_integration_tests. They're written in ruby though, sorry :)