### PR TITLE
pause-tube should check tube name is ok

### DIFF
--- a/prot.c
+++ b/prot.c
@@ -1582,6 +1582,7 @@ dispatch_cmd(Conn *c)
         if (r) return reply_msg(c, MSG_BAD_FORMAT);
 
         *delay_buf = '\0';
+        if (!name_is_ok(name, 200)) return reply_msg(c, MSG_BAD_FORMAT);
         t = tube_find(name);
         if (!t) return reply_msg(c, MSG_NOTFOUND);
 


### PR DESCRIPTION
This change updates pause-tube to return BAD_FORMAT when an invalid tube name is supplied. At present pause-tube will return NOT_FOUND after it fails to find an invalid tube.

This is more of a consistency thing than a bug, per se. 

ct tests all pass.