### PR TITLE
Use 64 bit ints for bytes used/reserved and ratio

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -327,8 +327,8 @@ struct Wal {
     File   *tail;
     int    nfile;
     int    next;
-    int    resv;  // bytes reserved
-    int    alive; // bytes in use
+    int64  resv;  // bytes reserved
+    int64  alive; // bytes in use
     int64  nmig;  // migrations
     int64  nrec;  // records written ever
     int    wantsync;

--- a/walg.c
+++ b/walg.c
@@ -94,7 +94,7 @@ ratio(Wal *w)
     int64 n, d;
 
     d = w->alive + w->resv;
-    n = w->nfile*w->filesize - d;
+    n = (int64)w->nfile * (int64)w->filesize - d;
     if (!d) return 0;
     return n / d;
 }

--- a/walg.c
+++ b/walg.c
@@ -91,7 +91,7 @@ usenext(Wal *w)
 static int
 ratio(Wal *w)
 {
-    int n, d;
+    int64 n, d;
 
     d = w->alive + w->resv;
     n = w->nfile*w->filesize - d;


### PR DESCRIPTION
This fixes an integer overflow in the free/used ratio calculation for
binlog compaction, and allows for tracking more than ~2.1GB of free or
used data in beanstalkd.

Fixes kr/beanstalkd#276