### PR TITLE
Makefile: resolved parallel install issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,10 @@ $(TARG): $(OFILES) $(MOFILE)
 	$(LINK.o) -o $@ $^ $(LDLIBS)
 
 .PHONY: install
-install: $(BINDIR) $(BINDIR)/$(TARG)
-
-$(BINDIR):
-	$(INSTALL) -d $@
+install: $(BINDIR)/$(TARG)
 
 $(BINDIR)/%: %
+	$(INSTALL) -d $(dir $@)
 	$(INSTALL) $< $@
 
 CLEANFILES:=$(CLEANFILES) $(TARG)


### PR DESCRIPTION
When installing within [Open Embedded](http://www.openembedded.org/) the make jobs parameter is by default shared between "all" and "install" [as per this doc](http://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#var-PARALLEL_MAKEINST). The beanstalkd Makefile was causing needless parallelization where the beanstalkd binary may be installed before the directory is created.