### PR TITLE
Fix version number output in stats

### DIFF
--- a/prot.c
+++ b/prot.c
@@ -176,7 +176,7 @@ size_t job_data_size_limit = JOB_DATA_SIZE_LIMIT_DEFAULT;
     "current-waiting: %u\n" \
     "total-connections: %u\n" \
     "pid: %ld\n" \
-    "version: %s\n" \
+    "version: \"%s\"\n" \
     "rusage-utime: %d.%06d\n" \
     "rusage-stime: %d.%06d\n" \
     "uptime: %u\n" \


### PR DESCRIPTION
The version number was previously being output as a number. In the case of the current version (1.10) this was parsed as 1.1 by several YAML parsers, including Ruby's YAML, JavaScript's js-yaml and Perl 6's YAMLish. In order for the version number to be parsed correctly it needs to be a string since the trailing zeros are significant.

This change shouldn't affect any existing parsers as the ones that got the correct number are parsing all values as strings anyway.

Of course, since this won't be released until a later version, it won't help. At least not until 1.20 or 2.10.