### PR TITLE
Update protocol.txt - stats-job & ttr

### DIFF
--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -447,6 +447,8 @@ to scalars. It contains these keys:
  - "pri" is the priority value set by the put, release, or bury commands.
 
  - "age" is the time in seconds since the put command that created this job.
+ 
+ - "ttr" is the TTR time in seconds of this job
 
  - "time-left" is the number of seconds left until the server puts this job
    into the ready queue. This number is only meaningful if the job is


### PR DESCRIPTION
From protocol.txt:
"Both the TTR and the actual time left can be
found in response to the stats-job command."
I saw perl module - there is too in stats-job should be "ttr" stat info
But in the protocol.txt for stats-job there is not "ttr" description. I think it's doc's error