### PR TITLE
Flag to put beanstalkd into the background

### DIFF
--- a/dat.h
+++ b/dat.h
@@ -378,6 +378,8 @@ struct Server {
     char *addr;
     char *user;
 
+    int   bg;
+
     Wal    wal;
     Socket sock;
     Heap   conns;

--- a/doc/beanstalkd.ronn
+++ b/doc/beanstalkd.ronn
@@ -35,6 +35,10 @@ and format of the `beanstalkd` protocol.
   (Do not use this option, except to negate `-n`. Both `-c` and `-n`
   will likely be removed in a future `beanstalkd` release.)
 
+* `-D`:
+  Daemonize: fork off a background process and print its process ID to
+  stdout.
+
 * `-f` <ms>:
   Call fsync(2) at most once every <ms> milliseconds. Larger values
   for <ms> reduce disk activity and improve speed at the cost of

--- a/main.c
+++ b/main.c
@@ -56,6 +56,8 @@ main(int argc, char **argv)
     setlinebuf(stdout);
     optparse(&srv, argv+1);
 
+    srvbg(&srv);
+
     if (verbose) {
         printf("pid %d\n", getpid());
     }

--- a/serv.c
+++ b/serv.c
@@ -1,12 +1,15 @@
+#include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <unistd.h>
 #include "dat.h"
 
 struct Server srv = {
     Portdef,
     NULL,
     NULL,
+    0,
     {
         Filesizedef,
     },
@@ -63,4 +66,20 @@ void
 srvaccept(Server *s, int ev)
 {
     h_accept(s->sock.fd, ev, s);
+}
+
+void
+srvbg(Server *s)
+{
+    pid_t pid;
+
+    if (s->bg) {
+        pid = fork();
+        if (pid) {
+           printf("%d\n", (int)pid);
+           fflush(stdout);
+           _exit(0);
+        }
+        setsid();
+    }
 }

--- a/util.c
+++ b/util.c
@@ -100,6 +100,7 @@ usage(int code)
             "\n"
             "Options:\n"
             " -b DIR   wal directory\n"
+            " -D       put server into the background (daemonize)\n"
             " -f MS    fsync at most once every MS milliseconds"
                        " (use -f0 for \"always fsync\")\n"
             " -F       never fsync (default)\n"
@@ -183,6 +184,9 @@ optparse(Server *s, char **argv)
                     break;
                 case 'u':
                     s->user = EARGF(flagusage("-u"));
+                    break;
+                case 'D':
+                    s->bg = 1;
                     break;
                 case 'b':
                     s->wal.dir = EARGF(flagusage("-b"));


### PR DESCRIPTION
This change adds a flag (-D), which causes beanstalkd to fork off a child process and print its PID to stdout from the parent process. The difference between this and running beanstalkd in the background is the process forked with the -D flag calls setsid(), which dissociates it from the controlling terminal and starts a new process group.

I couldn't think of a way to unit test this change.