### PR TITLE
include time.h for clock_gettime function definitions

### DIFF
--- a/ct/ct.c
+++ b/ct/ct.c
@@ -13,6 +13,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <sys/time.h>
+#include <time.h>
 #include <stdint.h>
 #include "internal.h"
 #include "ct.h"


### PR DESCRIPTION
I've taken package maintainership in fedora / epel. One of many compilation error messages is that clock_gettime is implicitly defined. Its fixed by including <time.h> as this patch does.