### PR TITLE
static const compilation error

### DIFF
--- a/ct/ct.c
+++ b/ct/ct.c
@@ -24,7 +24,7 @@ static int64 bstart, bdur;
 static int btiming; // bool
 static int64 bbytes;
 static const int64 Second = 1000 * 1000 * 1000;
-static const int64 BenchTime = Second;
+static const int64 BenchTime = 1000 * 1000 * 1000;
 static const int MaxN = 1000 * 1000 * 1000;
 
 


### PR DESCRIPTION
Fedora has strict compilation flags. The static const int64 isn't strictly valid C apparently. With this change the compilation succeeds in fedora.