### PR TITLE
printing int64 on different archs

### DIFF
--- a/ct/ct.c
+++ b/ct/ct.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <sys/time.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include "internal.h"
 #include "ct.h"
 
@@ -416,7 +417,7 @@ runbench(Benchmark *b)
         runbenchn(b, n);
     }
     if (b->status == 0) {
-        printf("%8d\t%10lld ns/op", n, b->dur/n);
+        printf("%8d\t%10"PRId64" ns/op", n, b->dur/n);
         if (b->bytes > 0) {
             double mbs = 0;
             if (b->dur > 0) {


### PR DESCRIPTION
There are warnings about size mis-matches. Including inttypes.h and using the constant fixes the issue so that the print format is the same regardless of x86_64 or i686. 