### PR TITLE
use syslog as well as writing to stderr for warnings

### DIFF
--- a/main.c
+++ b/main.c
@@ -70,7 +70,7 @@ main(int argc, char **argv)
     if (r == -1) twarnx("make_server_socket()"), exit(111);
     srv.sock.fd = r;
 
-    syslog(LOG_DEBUG, "Starting up on %s:%d", srv.addr, srv.port);
+    syslog(LOG_DEBUG, "Starting up on [%s]:%s", srv.addr, srv.port);
 
     prot_init();
 

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <pwd.h>
 #include <fcntl.h>
+#include <syslog.h>
 #include "dat.h"
 
 static void
@@ -56,13 +57,20 @@ main(int argc, char **argv)
     setlinebuf(stdout);
     optparse(&srv, argv+1);
 
+    openlog("beanstalkd", LOG_PID, LOG_DAEMON);
+
     if (verbose) {
+        setlogmask(LOG_UPTO(LOG_DEBUG));
         printf("pid %d\n", getpid());
+    } else {
+        setlogmask(LOG_UPTO(LOG_INFO));
     }
 
     r = make_server_socket(srv.addr, srv.port);
     if (r == -1) twarnx("make_server_socket()"), exit(111);
     srv.sock.fd = r;
+
+    syslog(LOG_DEBUG, "Starting up on %s:%d", srv.addr, srv.port);
 
     prot_init();
 

--- a/net.c
+++ b/net.c
@@ -7,6 +7,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <syslog.h>
 #include "dat.h"
 #include "sd-daemon.h"
 
@@ -110,8 +111,10 @@ make_server_socket(char *host, char *port)
           }
           if (ai->ai_family == AF_INET6) {
               printf("bind %d [%s]:%s\n", fd, h, p);
+              syslog(LOG_DEBUG, "bind %d [%s]:%s", fd, h, p);
           } else {
               printf("bind %d %s:%s\n", fd, h, p);
+              syslog(LOG_DEBUG, "bind %d %s:%s", fd, h, p);
           }
       }
       r = bind(fd, ai->ai_addr, ai->ai_addrlen);

--- a/prot.c
+++ b/prot.c
@@ -13,6 +13,7 @@
 #include <netinet/in.h>
 #include <inttypes.h>
 #include <stdarg.h>
+#include <syslog.h>
 #include "dat.h"
 
 /* job body cannot be greater than this many bytes long */
@@ -1921,6 +1922,7 @@ h_accept(const int fd, const short which, Server *s)
         return;
     }
     if (verbose) {
+        syslog(LOG_DEBUG, "accept %d", cfd);
         printf("accept %d\n", cfd);
     }
 
@@ -1929,6 +1931,7 @@ h_accept(const int fd, const short which, Server *s)
         twarn("getting flags");
         close(cfd);
         if (verbose) {
+            syslog(LOG_DEBUG, "close %d", cfd);
             printf("close %d\n", cfd);
         }
         update_conns();
@@ -1940,6 +1943,7 @@ h_accept(const int fd, const short which, Server *s)
         twarn("setting O_NONBLOCK");
         close(cfd);
         if (verbose) {
+            syslog(LOG_DEBUG, "close %d", cfd);
             printf("close %d\n", cfd);
         }
         update_conns();
@@ -1951,6 +1955,7 @@ h_accept(const int fd, const short which, Server *s)
         twarnx("make_conn() failed");
         close(cfd);
         if (verbose) {
+            syslog(LOG_DEBUG, "close %d", cfd);
             printf("close %d\n", cfd);
         }
         update_conns();
@@ -1966,6 +1971,7 @@ h_accept(const int fd, const short which, Server *s)
         twarn("sockwant");
         close(cfd);
         if (verbose) {
+            syslog(LOG_DEBUG, "close %d", cfd);
             printf("close %d\n", cfd);
         }
         update_conns();

--- a/util.c
+++ b/util.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
+#include <syslog.h>
 #include "sd-daemon.h"
 #include "dat.h"
 
@@ -18,8 +19,14 @@ vwarnx(const char *err, const char *fmt, va_list args)
 {
     fprintf(stderr, "%s: ", progname);
     if (fmt) {
+        va_list copy_args;
+        va_copy(copy_args, args);
         vfprintf(stderr, fmt, args);
-        if (err) fprintf(stderr, ": %s", err);
+        vsyslog(LOG_WARNING, fmt, copy_args);
+        if (err) {
+            syslog(LOG_ERR, "%s", err);
+            fprintf(stderr, ": %s", err);
+        }
     }
     fputc('\n', stderr);
 }


### PR DESCRIPTION
It's a lot more convenient to have daemons log to syslog than print errors to stderr; this patch sends all of the `warn()` / `warnx()` / etc. logging to syslog, as well as adding a log line on startup.