### PR TITLE
MOD: w->next change to max in function walread

### DIFF
--- a/walg.c
+++ b/walg.c
@@ -439,13 +439,13 @@ waldirlock(Wal *w)
 
 
 void
-walread(Wal *w, job list, int min, int max)
+walread(Wal *w, job list, int min)
 {
     File *f;
     int i, fd;
     int err = 0;
 
-    for (i = min; i < max; i++) {
+    for (i = min; i < w->next; i++) {
         f = new(File);
         if (!f) {
             twarnx("OOM");
@@ -485,7 +485,7 @@ walinit(Wal *w, job list)
     int min;
 
     min = walscandir(w);
-    walread(w, list, min, w->next);
+    walread(w, list, min);
 
     // first writable file
     if (!makenextfile(w)) {

--- a/walg.c
+++ b/walg.c
@@ -445,7 +445,7 @@ walread(Wal *w, job list, int min, int max)
     int i, fd;
     int err = 0;
 
-    for (i = min; i < w->next; i++) {
+    for (i = min; i < max; i++) {
         f = new(File);
         if (!f) {
             twarnx("OOM");


### PR DESCRIPTION
hello @kr 

I think it's a good idea to use max to replace w->next in function walread.

```c
void
walread(Wal *w, job list, int min, int max)
{
     File *f;
     int i, fd;
     int err = 0;
     
     for (i = min; i < w->next; i++) {
         ...
     }
}
```