### PR TITLE
Use wiki for deployment/automated installation tools

### DIFF
--- a/download.md
+++ b/download.md
@@ -90,19 +90,7 @@ Just type:
 
 ## Automated installation
 
-### Chef
-
-The [beanstalkd community cookbook](http://community.opscode.com/cookbooks/beanstalkd) can be found here at [escapestudios-cookbooks/beanstalkd](https://github.com/escapestudios-cookbooks/beanstalkd)
-
-Other available cookbooks:
-
-* [digitalpioneers/public-cookbooks](https://github.com/digitalpioneers/public-cookbooks)
-
-### Puppet
-
-There are also some open source puppet modules available:
-
-* [Jimdo/puppet-beanstalkd](https://github.com/Jimdo/puppet-beanstalkd)
+See the "Deployment and automated installation" section on the [Tools][] page.
 
 ## Client Libraries
 


### PR DESCRIPTION
I stumbled across #215 and it just felt like it would be more natural to have on the [Tools page](https://github.com/kr/beanstalkd/wiki/Tools). I've updated the wiki page to include the puppet and chef stuff. This pull request simply refers users there.